### PR TITLE
Fix issue with pytest_cmdline_preparse

### DIFF
--- a/pytest_plugin/pytest_pymtl3.py
+++ b/pytest_plugin/pytest_pymtl3.py
@@ -66,11 +66,6 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
   pass
 
-def pytest_cmdline_preparse(config, args):
-  """Don't write *.pyc and __pycache__ files."""
-  import sys
-  sys.dont_write_bytecode = True
-
 def pytest_runtest_setup(item):
   if _any_opts_present(item.config) and 'cmdline_opts' not in item.fixturenames:
     pytest.skip("'cmdline_opts' is required by pytest commandline but not used")


### PR DESCRIPTION
Ref: https://github.com/pymtl/pymtl3/commit/eea5ff49e06b303123097dc4d9e163790c0f58d6#diff-4d10e74d56f87ac5e84e3728455265afa88f9572cf25555a36730cf17eb66d41L69

Fix issue with pytest_cmdline_preparse
The pytest_cmdline_preparse hook is now deprecated. I think there should be a way to achieve the same effect using pytest_load_initial_conftests

https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_cmdline_preparse

However, were were using this to hook to prevent *.pyc and __pycache__ files from being generated. I think it is fine for now to just go back to generating these files.